### PR TITLE
simple-salesforce was updated and the integration app needs to be updated too

### DIFF
--- a/kicksaw_integration_app_client/__init__.py
+++ b/kicksaw_integration_app_client/__init__.py
@@ -84,7 +84,8 @@ class SFBulkType(BaseSFBulkType):
             self.headers,
             self.session,
         )
-        error_client.insert(error_objects, batch_size=batch_size)
+        if error_objects:
+            error_client.insert(error_objects, batch_size=batch_size)
 
 
 class SFBulkHandler(BaseSFBulkHandler):


### PR DESCRIPTION
simple-salesforce was updated and the integration app does not work anymore. I am getting the error `ValueError: data should not be empty for insert`. The new change in simple salesforce https://github.com/simple-salesforce/simple-salesforce/blob/master/simple_salesforce/bulk.py